### PR TITLE
Feat/1us - US 8

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -4,4 +4,8 @@ class BulkDiscountsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discounts = @merchant.bulk_discounts.all
   end
+
+  def show 
+    
+  end
 end

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -6,6 +6,8 @@ class BulkDiscountsController < ApplicationController
   end
 
   def show 
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
   end
 
   def new 
@@ -27,8 +29,8 @@ class BulkDiscountsController < ApplicationController
 
   def destroy
     @merchant = Merchant.find(params[:merchant_id])
-    @bulk_discounts = @merchant.bulk_discounts.find(params[:id])
-    @bulk_discounts.destroy
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    @bulk_discount.destroy
 
     redirect_to merchant_bulk_discounts_path(@merchant)
 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -25,6 +25,15 @@ class BulkDiscountsController < ApplicationController
 
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discounts = @merchant.bulk_discounts.find(params[:id])
+    @bulk_discounts.destroy
+
+    redirect_to merchant_bulk_discounts_path(@merchant)
+
+  end
+
   private 
 
   def bulk_discount_params

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,0 +1,7 @@
+class BulkDiscountsController < ApplicationController
+
+  def index 
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discounts = @merchant.bulk_discounts.all
+  end
+end

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -9,9 +9,23 @@ class BulkDiscountsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discount = @merchant.bulk_discounts.find(params[:id])
   end
-
+  
   def new 
     @merchant = Merchant.find(params[:merchant_id])
+  end
+  
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+  end
+
+  def update 
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    @bulk_discount.update(bulk_discount_params)
+
+    redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+
   end
 
   def create 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -6,6 +6,28 @@ class BulkDiscountsController < ApplicationController
   end
 
   def show 
-    
+  end
+
+  def new 
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def create 
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.new(bulk_discount_params)
+
+    if @bulk_discount.save
+      redirect_to merchant_bulk_discounts_path(@merchant)
+      flash[:alert] = 'Bulk discount created'
+    else
+      redirect_to new_merchant_bulk_discount_path(@merchant) #???
+    end
+
+  end
+
+  private 
+
+  def bulk_discount_params
+    params.permit(:percentage_discount, :quantity_threshold)
   end
 end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,3 +1,7 @@
 class BulkDiscount < ApplicationRecord
   belongs_to :merchant
+
+  validates :percentage_discount, presence: true
+  validates :quantity_threshold, presence: true 
+
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -19,21 +19,18 @@ class Invoice < ApplicationRecord
     total = 0
     invoice_items.each do |invoice_item|
       discount = invoice_item.item.merchant.bulk_discounts
-      .where('quantity_threshold <= ?', invoice_item.quantity)
-      .order(percentage_discount: :desc).first
-      
+        .where('quantity_threshold <= ?', invoice_item.quantity)
+        .order(percentage_discount: :desc)
+        .first
+
       if discount 
-        total += invoice_item.unit_price * invoice_item.quantity * (1 - discount.percentage_discount.to_f / 100.0)
+        total += invoice_item.unit_price * invoice_item.quantity * (1 - discount.percentage_discount / 100.0)
       else 
         total += invoice_item.unit_price * invoice_item.quantity
       end
-      # require 'pry'; binding.pry
     end
     total
-    # require 'pry'; binding.pry
   end
 
-
-
-
+  
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -14,4 +14,28 @@ class InvoiceItem < ApplicationRecord
     invoice_ids = InvoiceItem.where("status = 0 OR status = 1").pluck(:invoice_id)
     Invoice.order(created_at: :asc).find(invoice_ids)
   end
+
+  def applied_discount(discounts)
+    discounts
+      .where("quantity_threshold <= ?", self.quantity)
+      .pluck(:percentage_discount, :id)
+      .first
+  end 
+  #takes a collection of bulk discounts as an argument,filters these discounts to find the one that applies to the current quantity of the invoice item
+  #querying the discounts collection to find those where the quantity_threshold is less than or equal to the quantity of the item
+  #plucks the id and percentage_count of the matching discount
+  
+  def discount_applies(discounts)
+    # require 'pry'; binding.pry
+    discounts
+      .where("quantity_threshold <= ?", self.quantity)
+      .pluck(:quantity_threshold)
+      .any?
+  end
+
+  #akes a collection of bulk discounts as an argument,hecks whether any of these discounts apply to the current quantity of the invoice item If at least one such discount is found, it returns true
+  #determine whether a discount applies to the item,
+  #This method is used when we want to render the link for the bulk discount
+
+
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -12,8 +12,11 @@
         <%= f.submit 'Update Invoice' %>
     </section>
       <% end %>
-  <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
-  <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+      <section id="total-rev-<%= @invoice.id %>"> <! Add this section to make sure I'm getting back what I want>
+        <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
+        <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+        <p>Total Discount Revenue: <%= number_to_currency(@invoice.total_discounted_revenue) %>
+      </section>
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: merchant_bulk_discount_path(@merchant, @bulk_discount) , method: :patch do |form| %>
+  <%= form.label :percentage_discount  %>
+  <%= form.number_field :percentage_discount, value: @bulk_discount.percentage_discount %>
+
+  <%= form.label :quantity_threshold %>
+  <%= form.number_field :quantity_threshold, value: @bulk_discount.quantity_threshold %>
+
+  <%= form.submit 'Update Bulk Discount' %>
+<% end %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -7,3 +7,5 @@
     <%= link_to 'Details', merchant_bulk_discount_path(@merchant, bulk_discount) %>
   <div>
 <% end %>
+
+<%= link_to 'Create A New Discount', new_merchant_bulk_discount_path(@merchant) %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Merchant Discounts:</h1>
+
+
+<% @bulk_discounts.each do |bulk_discount| %>
+  <div>
+    <p>Percentage Discount: <%= bulk_discount.percentage_discount %> Quantity Threshold: <%= bulk_discount.quantity_threshold %></p>
+    <%= link_to 'Details', merchant_bulk_discount_path(@merchant, bulk_discount) %>
+  <div>
+<% end %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -3,8 +3,10 @@
 
 <% @bulk_discounts.each do |bulk_discount| %>
   <div>
-    <p>Percentage Discount: <%= bulk_discount.percentage_discount %> Quantity Threshold: <%= bulk_discount.quantity_threshold %></p>
-    <%= link_to 'Details', merchant_bulk_discount_path(@merchant, bulk_discount) %>
+    <section id="bulk_discount-<%= bulk_discount.id %>">
+      <p>Percentage Discount: <%= bulk_discount.percentage_discount %> Quantity Threshold: <%= bulk_discount.quantity_threshold %></p> <%= button_to "Delete Bulk Discount", merchant_bulk_discount_path(@merchant, bulk_discount),method: :delete, data: { turbo_method: :delete } %>
+      <%= link_to 'Details', merchant_bulk_discount_path(@merchant, bulk_discount) %>
+    </section>
   <div>
 <% end %>
 

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: merchant_bulk_discounts_path(@merchant), method: :post do |form| %>
+  <%= form.label :percentage_discount%>
+  <%= form.number_field :percentage_discount%>
+
+  <%= form.label :quantity_threshold%>
+  <%= form.number_field :quantity_threshold%>
+
+  <%= form.submit 'Create New Discount' %>
+<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,5 +1,6 @@
 
 
-  <p>Percentage Discount: <%= @bulk_discount.percentage_discount %></p>
-  <p>Quantity Threshold: <%= @bulk_discount.quantity_threshold %></p>
+<p>Percentage Discount: <%= @bulk_discount.percentage_discount %></p>
+<p>Quantity Threshold: <%= @bulk_discount.quantity_threshold %></p>
  
+<%= link_to 'Edit Bulk Discount', edit_merchant_bulk_discount_path(@merchant, @bulk_discount)%>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,0 +1,5 @@
+
+
+  <p>Percentage Discount: <%= @bulk_discount.percentage_discount %></p>
+  <p>Quantity Threshold: <%= @bulk_discount.quantity_threshold %></p>
+ 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -31,3 +31,5 @@
     </section>
   </ul>
 </div>
+
+<%= link_to 'View All Discounts', merchant_bulk_discounts_path(@merchant)  %>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -26,6 +26,7 @@
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
         <th class="th1">Status</th>
+        <th class="th1">Link to Discount</th>
       </tr>
     </thead>
 
@@ -34,6 +35,7 @@
         <section id="the-status-<%= i.id %>">
           <tr class="tr">
             <td style="text-align:center"><%= i.item.name %></td>
+            <td style="text-align:center"><%= i.item.name %></td>
             <td style="text-align:center"><%= i.quantity %></td>
             <td style="text-align:center">$<%= i.unit_price %></td>
             <td style="text-align:center">
@@ -41,11 +43,18 @@
                 <%= f.select :status, Invoice.statuses.keys, selected: "#{@invoice.status}" %>
                 <%= f.submit 'Update Invoice' %>
               <% end %>
-              </td>
+            </td>
+            <% has_discounts = !i.item.merchant.bulk_discounts.empty? %> <! This line checks if the current invoice item (i) has any associated bulk discounts. It sets has_discounts to true >
+            <% applies =  i.discount_applies(i.item.merchant.bulk_discounts) %> <! This method checks if any bulk discounts apply to the current quantity of the item,  by calling the discount_applies>
+            <% discount =  i.applied_discount(i.item.merchant.bulk_discounts)%> <!This method searches among the provided bulk discounts to find the one that applies to the current quantity of the item.>
+
+            <! if both conditions are met it will render the table containing the link to the show page of the bulk_discount that applies to the item>
+            <% if has_discounts && applies %> <! verifies that the item has associated bulk discounts and that at least one of them applies to the current quantity of the item>
+              <td style="text-align:center">$<%= link_to "#{discount[0]}% off applied", merchant_bulk_discount_path(i.item.merchant, discount[1]), method: :get %></td>
+            <% end %>
           </tr>
         </section>
       <% end %>
     </tbody>
   </table>
-
 </body>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,7 +12,7 @@
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
   <p>Total Revenue: <%= @invoice.total_revenue %></p>
-
+    <p>Total Discounted Revenue: <%= @invoice.total_discounted_revenue %></p>
 
   <h4>Customer:</h4>
     <%= @customer.first_name %> <%= @customer.last_name %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show]
+    resources :bulk_discounts, only: [:index, :show, :new, :create]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
+    resources :bulk_discounts, only: [:index, :show]
   end
+
 
   namespace :admin do
     resources :dashboard, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 
 

--- a/db/migrate/20240229230701_create_bulk_discounts.rb
+++ b/db/migrate/20240229230701_create_bulk_discounts.rb
@@ -1,7 +1,7 @@
 class CreateBulkDiscounts < ActiveRecord::Migration[7.1]
   def change
     create_table :bulk_discounts do |t|
-      t.integer :percentage_discount
+      t.float :percentage_discount
       t.integer :quantity_threshold
       t.references :merchant, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_230701) do
   enable_extension "plpgsql"
 
   create_table "bulk_discounts", force: :cascade do |t|
-    t.integer "percentage_discount"
+    t.float "percentage_discount"
     t.integer "quantity_threshold"
     t.bigint "merchant_id", null: false
     t.datetime "created_at", null: false

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -2,12 +2,42 @@ require "rails_helper"
 
 RSpec.describe "Merchant Bulk Discounts Index" do
   before(:each) do
-
+    @merchant1 = Merchant.create(name: "Merchant 1")
+    @merchant2 = Merchant.create(name: "Merchant 2")
+    
+    # Create Bulk Discounts for Merchant 1
+    @bulk_discount_merchant1_1 = BulkDiscount.create(percentage_discount: 10, quantity_threshold: 5, merchant: @merchant1)
+    @bulk_discount_merchant1_2 = BulkDiscount.create(percentage_discount: 20, quantity_threshold: 10, merchant: @merchant1)
+    
+    # Create Bulk Discounts for Merchant 2
+    @bulk_discount_merchant1_3 = BulkDiscount.create(percentage_discount: 15, quantity_threshold: 5, merchant: @merchant2)
   end
+  
+  describe 'US 1' do
+  it 'has a link to view all discounts ' do
+    visit merchant_dashboard_index_path(@merchant1)
+    # When I visit my merchant dashboard
 
-  describe '#initialize' do
-    it 'exists' do
-      expect().to eq()
+    expect(page).to have_link('View All Discounts')
+    # Then I see a link to view all my discounts
+
+    click_link('View All Discounts')
+    # When I click this link
+    
+    expect(current_path).to eq( merchant_bulk_discounts_path(@merchant1))
+    # Then I am taken to my bulk discounts index page
+    # save_and_open_page
+    expect(page).to have_content('Merchant Discounts:')
+    expect(page).to have_content('Percentage Discount: 10 Quantity Threshold: 5')
+    expect(page).to have_content('Percentage Discount: 20 Quantity Threshold: 10')
+    # Where I see all of my bulk discounts including their
+    # percentage discount and quantity thresholds
+    
+    expect(page).to_not have_content('Percentage Discount: 15 Quantity Threshold: 5')
+    
+    expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1))
+    expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_2))
+    # And each bulk discount listed includes a link to its show page
     end
   end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "Merchant Bulk Discounts Index" do
       # Then I am taken to my bulk discounts index page
       # save_and_open_page
       expect(page).to have_content('Merchant Discounts:')
-      expect(page).to have_content('Percentage Discount: 10 Quantity Threshold: 5')
-      expect(page).to have_content('Percentage Discount: 20 Quantity Threshold: 10')
+      expect(page).to have_content('Percentage Discount: 10.0 Quantity Threshold: 5')
+      expect(page).to have_content('Percentage Discount: 20.0 Quantity Threshold: 10')
       # Where I see all of my bulk discounts including their
       # percentage discount and quantity thresholds
       
@@ -69,7 +69,7 @@ RSpec.describe "Merchant Bulk Discounts Index" do
 
       expect(page).to have_content('Bulk discount created')
 
-      expect(page).to have_content('Percentage Discount: 15 Quantity Threshold: 10')
+      expect(page).to have_content('Percentage Discount: 15.0 Quantity Threshold: 10')
       # And I see my new bulk discount listed
     end
 

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -14,30 +14,90 @@ RSpec.describe "Merchant Bulk Discounts Index" do
   end
   
   describe 'US 1' do
-  it 'has a link to view all discounts ' do
-    visit merchant_dashboard_index_path(@merchant1)
-    # When I visit my merchant dashboard
+    it 'has a link to view all discounts ' do
+      visit merchant_dashboard_index_path(@merchant1)
+      # save_and_open_page
+      # When I visit my merchant dashboard
 
-    expect(page).to have_link('View All Discounts')
-    # Then I see a link to view all my discounts
+      expect(page).to have_link('View All Discounts')
+      # Then I see a link to view all my discounts
 
-    click_link('View All Discounts')
-    # When I click this link
-    
-    expect(current_path).to eq( merchant_bulk_discounts_path(@merchant1))
-    # Then I am taken to my bulk discounts index page
-    # save_and_open_page
-    expect(page).to have_content('Merchant Discounts:')
-    expect(page).to have_content('Percentage Discount: 10 Quantity Threshold: 5')
-    expect(page).to have_content('Percentage Discount: 20 Quantity Threshold: 10')
-    # Where I see all of my bulk discounts including their
-    # percentage discount and quantity thresholds
-    
-    expect(page).to_not have_content('Percentage Discount: 15 Quantity Threshold: 5')
-    
-    expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1))
-    expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_2))
-    # And each bulk discount listed includes a link to its show page
+      click_link('View All Discounts')
+      # When I click this link
+      
+      expect(current_path).to eq( merchant_bulk_discounts_path(@merchant1))
+      # Then I am taken to my bulk discounts index page
+      # save_and_open_page
+      expect(page).to have_content('Merchant Discounts:')
+      expect(page).to have_content('Percentage Discount: 10 Quantity Threshold: 5')
+      expect(page).to have_content('Percentage Discount: 20 Quantity Threshold: 10')
+      # Where I see all of my bulk discounts including their
+      # percentage discount and quantity thresholds
+      
+      expect(page).to_not have_content('Percentage Discount: 15 Quantity Threshold: 5')
+      
+      expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1))
+      expect(page).to have_link('Details', href: merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_2))
+      # And each bulk discount listed includes a link to its show page
     end
   end
+
+  describe 'US 2' do
+    it 'creates a bulk discount for a merchant' do
+      merchant = Merchant.create(name: "Merchant with no bulk discounts")
+
+      visit merchant_bulk_discounts_path(merchant)
+      # When I visit my bulk discounts index
+
+      expect(page).to have_link('Create A New Discount')
+      # Then I see a link to create a new discount
+
+      click_link('Create A New Discount')
+      # When I click this link
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path(merchant))
+      # Then I am taken to a new page where I see a form to add a new bulk discount
+
+
+      fill_in :percentage_discount, with: 15
+      fill_in :quantity_threshold, with: 10
+      click_button("Create New Discount")
+      # When I fill in the form with valid data
+
+      expect(current_path).to eq(merchant_bulk_discounts_path(merchant))
+      # Then I am redirected back to the bulk discount index
+
+      expect(page).to have_content('Bulk discount created')
+
+      expect(page).to have_content('Percentage Discount: 15 Quantity Threshold: 10')
+      # And I see my new bulk discount listed
+    end
+
+    it 'does not fill in all attributes of a bulk discount SAD PATH' do
+      merchant = Merchant.create(name: "Merchant with no bulk discounts")
+
+      visit merchant_bulk_discounts_path(merchant)
+      # When I visit my bulk discounts index
+
+      expect(page).to have_link('Create A New Discount')
+      # Then I see a link to create a new discount
+
+      click_link('Create A New Discount')
+      # When I click this link
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path(merchant))
+      # Then I am taken to a new page where I see a form to add a new bulk discount
+
+
+      #fill_in :percentage_discount, with: 15
+      fill_in :quantity_threshold, with: 10
+      click_button("Create New Discount")
+      # When I fill in the form with invalid data
+
+      expect(current_path).to eq(new_merchant_bulk_discount_path(merchant))
+      
+
+    end
+  end
+
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -100,4 +100,28 @@ RSpec.describe "Merchant Bulk Discounts Index" do
     end
   end
 
+  describe 'US 3' do
+    it 'deletes a bulk discount ' do
+      visit merchant_bulk_discounts_path(@merchant1)
+      # When I visit my bulk discounts index
+
+      within("#bulk_discount-#{@bulk_discount_merchant1_1.id}") do
+        expect(page).to have_button("Delete Bulk Discount")
+        # save_and_open_page
+        # Then next to each bulk discount I see a button to delete it
+        click_button("Delete Bulk Discount")
+        # When I click this button
+        
+      end
+      
+      expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+      # Then I am redirected back to the bulk discounts index page
+      
+      # save_and_open_page
+
+      expect(page).to_not have_content('Percentage Discount: 5 Quantity Threshold: 10')
+      # And I no longer see the discount listed
+    end
+  end
+
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -110,8 +110,7 @@ RSpec.describe "Merchant Bulk Discounts Index" do
         # save_and_open_page
         # Then next to each bulk discount I see a button to delete it
         click_button("Delete Bulk Discount")
-        # When I click this button
-        
+        # When I click this button 
       end
       
       expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
@@ -121,6 +120,18 @@ RSpec.describe "Merchant Bulk Discounts Index" do
 
       expect(page).to_not have_content('Percentage Discount: 5 Quantity Threshold: 10')
       # And I no longer see the discount listed
+    end
+  end
+
+  describe 'US 4 ' do
+    it 'shows bulk discount attributes' do
+      
+      visit merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1)
+      # When I visit my bulk discount show page
+
+      expect(page).to have_content('Percentage Discount: 10')
+      expect(page).to have_content('Quantity Threshold: 5')
+      # Then I see the bulk discount's quantity threshold and percentage discount
     end
   end
 

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Bulk Discount show" do
+  before(:each) do
+    @merchant1 = Merchant.create(name: "Merchant 1")
+    @merchant2 = Merchant.create(name: "Merchant 2")
+    
+    # Create Bulk Discounts for Merchant 1
+    @bulk_discount_merchant1_1 = BulkDiscount.create(percentage_discount: 10, quantity_threshold: 5, merchant: @merchant1)
+    @bulk_discount_merchant1_2 = BulkDiscount.create(percentage_discount: 20, quantity_threshold: 10, merchant: @merchant1)
+    
+    # Create Bulk Discounts for Merchant 2
+    @bulk_discount_merchant1_3 = BulkDiscount.create(percentage_discount: 15, quantity_threshold: 5, merchant: @merchant2)
+  end
+
+  describe 'US 5' do
+    it 'Bulk Discount edit ' do
+      visit merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1 )
+      # When I visit my bulk discount show page
+
+      expect(page).to have_link('Edit Bulk Discount')
+      # Then I see a link to edit the bulk discount
+
+      click_link('Edit Bulk Discount')
+      # When I click this link
+
+      visit edit_merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1)
+      # Then I am taken to a new page with a form to edit the discount
+      
+      # save_and_open_page
+      # expect(page).to have_content(@bulk_discount_merchant1_1.percentage_discount)
+      # expect(page).to have_content('Quantity Threshold: 5')
+      expect(page).to have_field('Percentage discount', with: '10')
+      expect(page).to have_field('Quantity threshold', with: '5')
+
+      # And I see that the discounts current attributes are pre-poluated in the form
+      fill_in :percentage_discount, with: 20
+      fill_in :quantity_threshold, with: 5
+      click_button("Update Bulk Discount")
+      # When I change any/all of the information and click submit
+
+      expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @bulk_discount_merchant1_1))
+      # Then I am redirected to the bulk discount's show page
+
+      expect(page).to have_content('Percentage Discount: 20')
+      expect(page).to have_content('Quantity Threshold: 5')
+      # And I see that the discount's attributes have been updated
+    end
+  end
+end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Bulk Discount show" do
       # save_and_open_page
       # expect(page).to have_content(@bulk_discount_merchant1_1.percentage_discount)
       # expect(page).to have_content('Quantity Threshold: 5')
-      expect(page).to have_field('Percentage discount', with: '10')
+      expect(page).to have_field('Percentage discount', with: '10.0')
       expect(page).to have_field('Quantity threshold', with: '5')
 
       # And I see that the discounts current attributes are pre-poluated in the form

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "invoices show" do
       invoice = Invoice.create!(customer_id: customer.id, status: 2)
       invoice_item_1 = InvoiceItem.create!(invoice_id: invoice.id, item_id: item_1.id, quantity: 12, unit_price: 10, status: 2) #120 shampoo meets quantity threshold for bulk discount 1 which the price is 8 dollors now and the discount total is $96 for this item 
       invoice_item_2 = InvoiceItem.create!(invoice_id: invoice.id, item_id: item_2.id, quantity: 1, unit_price: 8, status: 2) #120 conditioner meets quantity threshold for bulk discount 2 the price of the item is now 6.8 bc 15% of 8 is 1.2 then 8-1.20 = $6.8 15 *6.8 = 102
-      #96 + 102                                                                                                                          
+                                                                                                                                
       # Create transactions for the invoices
       transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: invoice.id)
       # As a merchant
@@ -129,7 +129,7 @@ RSpec.describe "invoices show" do
       visit merchant_invoice_path(merchant1,invoice)
       # When I visit my merchant invoice show page
 
-      save_and_open_page
+      # save_and_open_page
       expect(page).to have_content('Total Revenue: 128.0')
       # Then I see the total revenue for my merchant from this invoice (not including discounts)
       

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -2,4 +2,11 @@ require 'rails_helper'
 
 RSpec.describe BulkDiscount, type: :model do
   it { should belong_to :merchant }
+
+  
+  describe 'validations' do
+    it { should validate_presence_of :percentage_discount}
+    it { should validate_presence_of :quantity_threshold}
+  end
+  
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -38,5 +38,23 @@ RSpec.describe InvoiceItem, type: :model do
     it 'incomplete_invoices' do
       expect(InvoiceItem.incomplete_invoices).to eq([@i1, @i3])
     end
+
+    it 'applied_discount' do
+      merchant = Merchant.create!(name: 'Hair Care')
+      bulk_discount = merchant.bulk_discounts.create!(percentage_discount: 20.0, quantity_threshold: 10)
+      invoice_item = InvoiceItem.new(quantity: 10)
+
+      discount_details = invoice_item.applied_discount(BulkDiscount)
+
+      expect(discount_details).to eq([20.0, bulk_discount.id])
+    end
+
+    it 'returns true if any bulk discount applies to the quantity' do
+      merchant = Merchant.create!(name: 'Hair Care')
+      BulkDiscount.create!(percentage_discount: 20.0, quantity_threshold: 10, merchant: merchant)
+      invoice_item = InvoiceItem.new(quantity: 12)
+
+      expect(invoice_item.discount_applies(BulkDiscount)).to eq(true)
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Invoice, type: :model do
   describe "instance methods" do
     before (:each) do 
       @merchant1 = Merchant.create!(name: 'Hair Care')
-      @discount1 = @merchant1.bulk_discounts.create!(percentage_discount: 20, quantity_threshold: 10)
+      @discount1 = @merchant1.bulk_discounts.create!(percentage_discount: 20.0, quantity_threshold: 10)
       @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
       @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
       @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -10,18 +10,25 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items) }
     it { should have_many :transactions}
+    it { should have_many(:bulk_discounts).through(:merchants) }
   end
   describe "instance methods" do
-    it "total_revenue" do
+    before (:each) do 
       @merchant1 = Merchant.create!(name: 'Hair Care')
+      @discount1 = @merchant1.bulk_discounts.create!(percentage_discount: 20, quantity_threshold: 10)
       @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
       @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
       @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
       @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
-      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 10, unit_price: 10, status: 2)
       @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+    end
+    it "total_revenue" do
+      expect(@invoice_1.total_revenue).to eq(110)
+    end
 
-      expect(@invoice_1.total_revenue).to eq(100)
+    it 'total_discounted_revenue' do
+      expect(@invoice_1.total_discounted_revenue).to eq(90)
     end
   end
 end


### PR DESCRIPTION
Added the feature of a Bulk discount. Bulk discount is eligible for all items that the merchant sells. Bulk discounts for one merchant should not affect items sold by another merchant. If an item meets the quantity threshold for multiple bulk discounts, only the one with the greatest percentage discount should be applied. f the quantity of an item ordered meets or exceeds the quantity threshold, then the percentage discount should apply to that item only.

1: Merchant Bulk Discounts Index

As a merchant
When I visit my merchant dashboard
Then I see a link to view all my discounts
When I click this link
Then I am taken to my bulk discounts index page
Where I see all of my bulk discounts including their
percentage discount and quantity thresholds
And each bulk discount listed includes a link to its show page

2: Merchant Bulk Discount Create

As a merchant
When I visit my bulk discounts index
Then I see a link to create a new discount
When I click this link
Then I am taken to a new page where I see a form to add a new bulk discount
When I fill in the form with valid data
Then I am redirected back to the bulk discount index
And I see my new bulk discount listed

3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a button to delete it
When I click this button
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed
4: Merchant Bulk Discount Show

As a merchant
When I visit my bulk discount show page
Then I see the bulk discount's quantity threshold and percentage discount

5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated

6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation

Note: We encourage you to use as much ActiveRecord as you can, but some Ruby is okay. Instead of a single query that sums the revenue of discounted items and the revenue of non-discounted items, we recommend creating a query to find the total discount amount, and then using Ruby to subtract that discount from the total revenue.

For an extra spicy challenge: try to find the total revenue of discounted and non-discounted items in one query! 


7: Merchant Invoice Show Page: Link to applied discounts

As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
Admin Invoice Show Page: Total Revenue and Discounted Revenue

8: Admin Invoice Show Page: Total Revenue and Discounted Revenue

As an admin
When I visit an admin invoice show page
Then I see the total revenue from this invoice (not including discounts)
And I see the total discounted revenue from this invoice which includes bulk discounts in the calculation
